### PR TITLE
Use pkce by default

### DIFF
--- a/lib/CotterVerify.d.ts
+++ b/lib/CotterVerify.d.ts
@@ -36,9 +36,11 @@ declare class Cotter {
     state: string | null;
     loaded: boolean;
     cotterIframeID: string;
+    verifier: string;
     constructor(config: Config);
     showForm(): void;
     removeForm(): void;
+    submitAuthorizationCode(payload: VerifyRespondResponse): Promise<void>;
     static StopSubmissionWithError(err: string, iframeID: string): void;
     static ContinueSubmit(payload: object, iframeID: string): void;
     static sendPost(data: object, iframeID: string): void;

--- a/lib/CotterVerify.js
+++ b/lib/CotterVerify.js
@@ -1,4 +1,13 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -22,6 +31,8 @@ class Cotter {
             this.state = Math.random().toString(36).substring(2, 15);
             localStorage.setItem("COTTER_STATE", this.state);
         }
+        // SUPPORT PKCE
+        this.verifier = generateVerifier();
         this.loaded = false;
         this.cotterIframeID =
             Math.random().toString(36).substring(2, 15) + "cotter-signup-iframe";
@@ -87,6 +98,9 @@ class Cotter {
                         this.config.OnSuccess(data.payload);
                     }
                     break;
+                case cID + "ON_SUBMIT_AUTHORIZATION_CODE":
+                    this.submitAuthorizationCode(data.payload);
+                    break;
                 case cID + "ON_ERROR":
                     if (this.config.OnError) {
                         this.config.OnError(data.payload);
@@ -136,12 +150,116 @@ class Cotter {
             ifrm.style.minHeight = "520px";
         }
         ifrm.style.overflow = "scroll";
-        ifrm.setAttribute("src", encodeURI(`${enum_1.default.CotterBaseURL}/signup?type=${this.config.Type}&domain=${this.config.Domain}&api_key=${this.config.ApiKeyID}&redirect_url=${this.config.RedirectURL}&state=${this.state}&id=${this.config.ContainerID}`));
+        challengeFromVerifier(this.verifier).then((challenge) => {
+            ifrm.setAttribute("src", encodeURI(`${enum_1.default.CotterBaseURL}/signup?challenge=${challenge}&type=${this.config.Type}&domain=${this.config.Domain}&api_key=${this.config.ApiKeyID}&redirect_url=${this.config.RedirectURL}&state=${this.state}&id=${this.config.ContainerID}`));
+        });
         ifrm.setAttribute("allowtransparency", "true");
     }
     removeForm() {
         var ifrm = document.getElementById(this.cotterIframeID);
         ifrm.remove();
+    }
+    submitAuthorizationCode(payload) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Getting code from payload
+            var authorizationCode = payload.authorization_code;
+            var challengeID = payload.challenge_id;
+            var state = payload.state;
+            var clientJson = payload.client_json;
+            var skipRedirectURL = this.config.RedirectURL === null ||
+                this.config.RedirectURL === undefined ||
+                (this.config.RedirectURL && this.config.RedirectURL.length <= 0) ||
+                this.config.SkipRedirectURL;
+            // State was set before the first request was sent
+            // This is making sure that the state returned is still the same
+            if (state !== this.state) {
+                if (this.config.OnError) {
+                    var err = "State is not the same as the original request.";
+                    console.log(err);
+                    this.config.OnError(err);
+                }
+            }
+            // Preparing data for PCKE token request
+            var data = {
+                code_verifier: this.verifier,
+                authorization_code: authorizationCode,
+                challenge_id: parseInt(challengeID),
+                redirect_url: skipRedirectURL
+                    ? new URL(window.location.href).origin
+                    : this.config.RedirectURL,
+            };
+            var self = this;
+            // Requesting oauth token from the PKCE endpoint
+            fetch(`${enum_1.default.CotterBackendURL}/verify/get_identity?oauth_token=true`, {
+                method: "POST",
+                headers: {
+                    API_KEY_ID: `${self.config.ApiKeyID}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(data),
+            })
+                .then(function (response) {
+                // If not successful, call OnError and return
+                if (response.status !== 200) {
+                    if (self.config.OnError) {
+                        var err = response;
+                        console.log(err);
+                        self.config.OnError(err);
+                    }
+                    return;
+                }
+                // Examine the text in the response
+                response.json().then(function (resp) {
+                    // Preparing data to return to the client
+                    var data = clientJson;
+                    data.token = resp.token;
+                    data[self.config.IdentifierField] = resp.identifier.identifier;
+                    data.oauth_token = resp.oauth_token;
+                    // If skipRedirectURL, send the data to the client's OnSuccess function
+                    if (skipRedirectURL || !self.config.RedirectURL) {
+                        self.config.OnSuccess(data);
+                        return;
+                    }
+                    else {
+                        // Otherwise, send POST request to the client's RedirectURL
+                        fetch(self.config.RedirectURL, {
+                            method: "POST",
+                            headers: {
+                                "Content-Type": "application/json",
+                            },
+                            body: JSON.stringify(data),
+                        })
+                            // Checking client's response
+                            .then((redirectResp) => {
+                            const contentType = redirectResp.headers.get("content-type");
+                            if (contentType &&
+                                contentType.indexOf("application/json") !== -1) {
+                                return redirectResp.json().then((redirectRespJSON) => {
+                                    self.config.OnSuccess(redirectRespJSON);
+                                });
+                            }
+                            else {
+                                return redirectResp.text().then((redirectRespText) => {
+                                    self.config.OnSuccess(redirectRespText);
+                                });
+                            }
+                        })
+                            .catch(function (error) {
+                            if (self.config.OnError) {
+                                console.log(error);
+                                self.config.OnError(error);
+                            }
+                        });
+                    }
+                });
+            })
+                .catch((error) => {
+                if (self.config.OnError) {
+                    console.log(error);
+                    self.config.OnError(error);
+                }
+            });
+        });
     }
     static StopSubmissionWithError(err, iframeID) {
         var postData = {
@@ -165,4 +283,34 @@ class Cotter {
     }
 }
 const isIFrame = (input) => input !== null && input.tagName === "IFRAME";
+function dec2hex(dec) {
+    return ("0" + dec.toString(16)).substr(-2);
+}
+function generateVerifier() {
+    var array = new Uint32Array(56 / 2);
+    window.crypto.getRandomValues(array);
+    return Array.from(array, dec2hex).join("");
+}
+function sha256(plain) {
+    // returns promise ArrayBuffer
+    const encoder = new TextEncoder();
+    const data = encoder.encode(plain);
+    return window.crypto.subtle.digest("SHA-256", data);
+}
+function base64urlencode(a) {
+    var str = "";
+    var bytes = new Uint8Array(a);
+    var len = bytes.byteLength;
+    for (var i = 0; i < len; i++) {
+        str += String.fromCharCode(bytes[i]);
+    }
+    return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function challengeFromVerifier(v) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var hashed = yield sha256(v);
+        var base64encoded = base64urlencode(hashed);
+        return base64encoded;
+    });
+}
 exports.default = Cotter;

--- a/lib/CotterVerify.js
+++ b/lib/CotterVerify.js
@@ -13,6 +13,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const enum_1 = __importDefault(require("./enum"));
+const helper_1 = require("./helper");
 class Cotter {
     constructor(config) {
         console.log("Using origin: ", new URL(window.location.href).origin);
@@ -32,7 +33,7 @@ class Cotter {
             localStorage.setItem("COTTER_STATE", this.state);
         }
         // SUPPORT PKCE
-        this.verifier = generateVerifier();
+        this.verifier = helper_1.generateVerifier();
         this.loaded = false;
         this.cotterIframeID =
             Math.random().toString(36).substring(2, 15) + "cotter-signup-iframe";
@@ -150,7 +151,7 @@ class Cotter {
             ifrm.style.minHeight = "520px";
         }
         ifrm.style.overflow = "scroll";
-        challengeFromVerifier(this.verifier).then((challenge) => {
+        helper_1.challengeFromVerifier(this.verifier).then((challenge) => {
             ifrm.setAttribute("src", encodeURI(`${enum_1.default.CotterBaseURL}/signup?challenge=${challenge}&type=${this.config.Type}&domain=${this.config.Domain}&api_key=${this.config.ApiKeyID}&redirect_url=${this.config.RedirectURL}&state=${this.state}&id=${this.config.ContainerID}`));
         });
         ifrm.setAttribute("allowtransparency", "true");
@@ -283,34 +284,4 @@ class Cotter {
     }
 }
 const isIFrame = (input) => input !== null && input.tagName === "IFRAME";
-function dec2hex(dec) {
-    return ("0" + dec.toString(16)).substr(-2);
-}
-function generateVerifier() {
-    var array = new Uint32Array(56 / 2);
-    window.crypto.getRandomValues(array);
-    return Array.from(array, dec2hex).join("");
-}
-function sha256(plain) {
-    // returns promise ArrayBuffer
-    const encoder = new TextEncoder();
-    const data = encoder.encode(plain);
-    return window.crypto.subtle.digest("SHA-256", data);
-}
-function base64urlencode(a) {
-    var str = "";
-    var bytes = new Uint8Array(a);
-    var len = bytes.byteLength;
-    for (var i = 0; i < len; i++) {
-        str += String.fromCharCode(bytes[i]);
-    }
-    return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-function challengeFromVerifier(v) {
-    return __awaiter(this, void 0, void 0, function* () {
-        var hashed = yield sha256(v);
-        var base64encoded = base64urlencode(hashed);
-        return base64encoded;
-    });
-}
 exports.default = Cotter;

--- a/src/CotterVerify.ts
+++ b/src/CotterVerify.ts
@@ -1,4 +1,5 @@
 import CotterEnum from "./enum";
+import { challengeFromVerifier, generateVerifier } from "./helper";
 
 interface Config {
   ApiKeyID: string;
@@ -338,38 +339,5 @@ class Cotter {
 
 const isIFrame = (input: HTMLElement | null): input is HTMLIFrameElement =>
   input !== null && input.tagName === "IFRAME";
-
-function dec2hex(dec: any) {
-  return ("0" + dec.toString(16)).substr(-2);
-}
-
-function generateVerifier() {
-  var array = new Uint32Array(56 / 2);
-  window.crypto.getRandomValues(array);
-  return Array.from(array, dec2hex).join("");
-}
-
-function sha256(plain: string) {
-  // returns promise ArrayBuffer
-  const encoder = new TextEncoder();
-  const data = encoder.encode(plain);
-  return window.crypto.subtle.digest("SHA-256", data);
-}
-
-function base64urlencode(a: ArrayBuffer) {
-  var str = "";
-  var bytes = new Uint8Array(a);
-  var len = bytes.byteLength;
-  for (var i = 0; i < len; i++) {
-    str += String.fromCharCode(bytes[i]);
-  }
-  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-async function challengeFromVerifier(v: string) {
-  var hashed = await sha256(v);
-  var base64encoded = base64urlencode(hashed);
-  return base64encoded;
-}
 
 export default Cotter;

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -1,0 +1,6 @@
+interface VerifyRespondResponse {
+  authorization_code: string;
+  challenge_id: string;
+  state: string;
+  client_json: any;
+}

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,0 +1,29 @@
+function dec2hex(dec) {
+  return ("0" + dec.toString(16)).substr(-2);
+}
+
+export function generateVerifier() {
+  var array = new Uint32Array(56 / 2);
+  window.crypto.getRandomValues(array);
+  return Array.from(array, dec2hex).join("");
+}
+
+function sha256(plain) {
+  // returns promise ArrayBuffer
+  const encoder = new TextEncoder();
+  const data = encoder.encode(plain);
+  return window.crypto.subtle.digest("SHA-256", data);
+}
+
+function base64urlencode(a) {
+  return btoa(String.fromCharCode.apply(null, new Uint8Array(a)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export async function challengeFromVerifier(v) {
+  var hashed = await sha256(v);
+  var base64encoded = base64urlencode(hashed);
+  return base64encoded;
+}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,4 +1,4 @@
-function dec2hex(dec) {
+function dec2hex(dec: any) {
   return ("0" + dec.toString(16)).substr(-2);
 }
 
@@ -8,21 +8,24 @@ export function generateVerifier() {
   return Array.from(array, dec2hex).join("");
 }
 
-function sha256(plain) {
+function sha256(plain: string) {
   // returns promise ArrayBuffer
   const encoder = new TextEncoder();
   const data = encoder.encode(plain);
   return window.crypto.subtle.digest("SHA-256", data);
 }
 
-function base64urlencode(a) {
-  return btoa(String.fromCharCode.apply(null, new Uint8Array(a)))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
+function base64urlencode(a: ArrayBuffer) {
+  var str = "";
+  var bytes = new Uint8Array(a);
+  var len = bytes.byteLength;
+  for (var i = 0; i < len; i++) {
+    str += String.fromCharCode(bytes[i]);
+  }
+  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
-export async function challengeFromVerifier(v) {
+export async function challengeFromVerifier(v: string) {
   var hashed = await sha256(v);
   var base64encoded = base64urlencode(hashed);
   return base64encoded;


### PR DESCRIPTION
- The new release of js.cotter.app will be sending requests using the PKCE flow by default, but will use the old flow if PKCE `code_challenge` is not specified.
- This update will enable clients to automatically use the PKCE flow, which prevents their `API_KEY_ID` from being used in websites other than the one listed in the dashboard.
- Clients will need to update `Allowed Origins & Redirect URL` in their dashboard for this to work. The default value for existing clients is `['*']` meaning any website can use their API keys. The default value for new clients is `[]`.