### PR TITLE
Make sure tokenHandler exists, don't call API when still fetching

### DIFF
--- a/lib/CotterVerify.js
+++ b/lib/CotterVerify.js
@@ -377,7 +377,7 @@ class CotterVerify {
                             IdentifierType: this.config.Type,
                             AlternativeMethod: this.config.AuthenticationMethodName,
                             Type: "LOGIN",
-                        });
+                        }, this.tokenHander);
                         web
                             .show()
                             .then((resp) => {

--- a/src/Cotter.ts
+++ b/src/Cotter.ts
@@ -76,21 +76,27 @@ export default class Cotter extends CotterVerify {
     this.config.RegisterWebAuthn = true;
     const available = await WebAuthn.available();
     if (!available) {
-      let web = new WebAuthn({
+      let web = new WebAuthn(
+        {
+          ApiKeyID: this.config.ApiKeyID,
+          Identifier: identifier,
+          Type: "REGISTRATION",
+          ErrorDisplay: "The browser or user device doesn't support WebAuthn.",
+          RegisterWebAuthn: true,
+        },
+        this.tokenHander
+      );
+      return await web.show();
+    }
+    let web = new WebAuthn(
+      {
         ApiKeyID: this.config.ApiKeyID,
         Identifier: identifier,
         Type: "REGISTRATION",
-        ErrorDisplay: "The browser or user device doesn't support WebAuthn.",
         RegisterWebAuthn: true,
-      });
-      return await web.show();
-    }
-    let web = new WebAuthn({
-      ApiKeyID: this.config.ApiKeyID,
-      Identifier: identifier,
-      Type: "REGISTRATION",
-      RegisterWebAuthn: true,
-    });
+      },
+      this.tokenHander
+    );
     return await web.show();
   }
 

--- a/src/CotterVerify.ts
+++ b/src/CotterVerify.ts
@@ -412,14 +412,17 @@ class CotterVerify {
           this.LoginWebAuthn = true;
           this.ContinueSubmitData = payload; // For use if WebAuthn failed
           // Start WebAuthn Login
-          let web = new WebAuthn({
-            ApiKeyID: this.config.ApiKeyID,
-            Identifier: payload.identifier,
-            IdentifierField: this.config.IdentifierField,
-            IdentifierType: this.config.Type,
-            AlternativeMethod: this.config.AuthenticationMethodName,
-            Type: "LOGIN",
-          });
+          let web = new WebAuthn(
+            {
+              ApiKeyID: this.config.ApiKeyID,
+              Identifier: payload.identifier,
+              IdentifierField: this.config.IdentifierField,
+              IdentifierType: this.config.Type,
+              AlternativeMethod: this.config.AuthenticationMethodName,
+              Type: "LOGIN",
+            },
+            this.tokenHander
+          );
 
           web
             .show()

--- a/src/handler/TokenHandler.ts
+++ b/src/handler/TokenHandler.ts
@@ -105,25 +105,25 @@ class TokenHandler {
   async getTokensFromRefreshToken(): Promise<OAuthToken> {
     return new Promise<OAuthToken>((resolve, reject) => {
       const checkTokenFetchProcess = () => {
-        if (this.tokenFetchingState === TOKEN_FETCHING_STATES.initial) {
-          this.getTokensFromRefreshTokenAPI();
-        } else if (
-          this.tokenFetchingState === TOKEN_FETCHING_STATES.ready &&
-          this.fetchTokenResp
-        ) {
-          resolve(this.fetchTokenResp);
-          return;
-        } else if (
-          this.tokenFetchingState === TOKEN_FETCHING_STATES.errorRetry
-        ) {
-          this.tokenFetchingState = TOKEN_FETCHING_STATES.initial;
-          reject();
-          return;
-        } else if (
-          this.tokenFetchingState === TOKEN_FETCHING_STATES.errorFatal
-        ) {
-          reject();
-          return;
+        switch (this.tokenFetchingState) {
+          case TOKEN_FETCHING_STATES.initial:
+            this.getTokensFromRefreshTokenAPI();
+            break;
+          case TOKEN_FETCHING_STATES.ready:
+            if (this.fetchTokenResp) {
+              resolve(this.fetchTokenResp);
+              return;
+            }
+            break;
+          case TOKEN_FETCHING_STATES.errorRetry:
+            this.tokenFetchingState = TOKEN_FETCHING_STATES.initial;
+            reject();
+            return;
+          case TOKEN_FETCHING_STATES.errorFatal:
+            reject();
+            return;
+          default:
+            break;
         }
         setTimeout(checkTokenFetchProcess, 0);
       };

--- a/src/handler/TokenHandler.ts
+++ b/src/handler/TokenHandler.ts
@@ -124,7 +124,7 @@ class TokenHandler {
   }
 
   // Returns access token
-  async getTokensFromRefreshTokenAPI(): Promise<OAuthToken> {
+  async getTokensFromRefreshTokenAPI(): Promise<void> {
     this.tokenFetchingState = TOKEN_FETCHING_STATES.fetching;
     this.fetchTokenResp = null;
     let refreshToken = null;
@@ -140,10 +140,10 @@ class TokenHandler {
       this.storeTokens(resp);
       this.tokenFetchingState = TOKEN_FETCHING_STATES.ready;
       this.fetchTokenResp = resp;
-      return resp;
+      return;
     } catch (err) {
       this.tokenFetchingState = TOKEN_FETCHING_STATES.error;
-      throw err;
+      return;
     }
   }
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,5 +1,6 @@
 import { Config, VerifySuccess } from "./binder";
 import WebAuthn from "./WebAuthn";
+import TokenHandler from "./handler/TokenHandler";
 
 function dec2hex(dec: any) {
   return ("0" + dec.toString(16)).substr(-2);
@@ -61,6 +62,7 @@ export const verificationProccessPromise = (self: {
   RegisterWebAuthn?: boolean;
   config: Config;
   Identifier?: string;
+  tokenHandler?: TokenHandler;
   onSuccess: (success: VerifySuccess) => void;
   onError: (error: any) => void;
 }) =>
@@ -76,14 +78,17 @@ export const verificationProccessPromise = (self: {
           // (always accompanied by forced email/phone verification)
           const originalResp = { ...self.verifySuccess };
           self.verifySuccess = undefined;
-          let web = new WebAuthn({
-            ApiKeyID: self.config.ApiKeyID,
-            Identifier: self.Identifier,
-            IdentifierField: self.config.IdentifierField,
-            OriginalResponse: originalResp,
-            IdentifierType: self.config.Type,
-            Type: "REGISTRATION",
-          });
+          let web = new WebAuthn(
+            {
+              ApiKeyID: self.config.ApiKeyID,
+              Identifier: self.Identifier,
+              IdentifierField: self.config.IdentifierField,
+              OriginalResponse: originalResp,
+              IdentifierType: self.config.Type,
+              Type: "REGISTRATION",
+            },
+            self.tokenHandler
+          );
           web
             .show()
             .then((resp: VerifySuccess) => {


### PR DESCRIPTION
- Make sure tokenHandler is passed into each class.
- Only call api to refresh token once, all other requests to refresh the token will wait for this one api call.